### PR TITLE
Use actions/setup-java@v2 and cache gradle, wrapper and buildSrc

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup JDK 1.8
+    - name: Setup JDK
       uses: actions/setup-java@v2
       with:
         java-version: '11'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - name: Setup JDK 1.8
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: '11'
+        distribution: 'zulu'
+    - name: Cache gradle, wrapper and buildSrc
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.job }}-
     - run: ./gradlew testDebugUnitTest


### PR DESCRIPTION
- Update to `actions/setup-java@v2`
- Use `actions/cache@v2` to allow caching dependencies and build outputs to improve workflow execution time.